### PR TITLE
Fix docker compose not found error

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -44,8 +44,8 @@ jobs:
     - name: 🔧 Validar configurações Docker
       run: |
         docker --version
-        docker-compose --version
-        docker-compose config
+        docker compose version
+        docker compose config
     
     - name: ✅ Validar templates
       run: |
@@ -109,7 +109,7 @@ jobs:
           cd /home/gcp-user/analise-cartao || { echo '📁 Diretório não existe, criando...'; mkdir -p /home/gcp-user/analise-cartao; cd /home/gcp-user/analise-cartao; }
           if [ -f docker-compose.yml ]; then
             echo '⏹️ Parando containers...'
-            docker-compose down || echo '⚠️ Nenhum container rodando'
+            docker compose down || echo '⚠️ Nenhum container rodando'
           else
             echo '📋 Primeira execução - sem containers para parar'
           fi
@@ -352,11 +352,11 @@ jobs:
           
           # Construir com cache otimizado
           echo '🔨 Construindo imagem...'
-          docker-compose build --no-cache web
+          docker compose build --no-cache web
           
           # Iniciar serviços
           echo '▶️ Iniciando serviços...'
-          docker-compose up -d
+          docker compose up -d
           
           # Aguardar inicialização
           echo '⏳ Aguardando inicialização...'
@@ -364,7 +364,7 @@ jobs:
           
           # Verificar status
           echo '📊 Status dos containers:'
-          docker-compose ps
+          docker compose ps
           
           echo '🎉 Deploy concluído!'
         "
@@ -386,9 +386,9 @@ jobs:
           ssh -i ~/.ssh/gcp_deploy ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_IP }} "
             cd /home/gcp-user/analise-cartao
             echo '🔍 Logs da aplicação:'
-            docker-compose logs --tail=20 web
+            docker compose logs --tail=20 web
             echo '🔍 Logs do Nginx:'
-            docker-compose logs --tail=10 nginx
+            docker compose logs --tail=10 nginx
           "
           exit 1
         fi
@@ -399,7 +399,7 @@ jobs:
         ssh -i ~/.ssh/gcp_deploy ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_IP }} "
           cd /home/gcp-user/analise-cartao
           echo '🐳 Containers:'
-          docker-compose ps
+          docker compose ps
           echo ''
           echo '💾 Uso de memória:'
           free -h


### PR DESCRIPTION
Update `docker-compose` commands to `docker compose` in GitHub Actions workflow to resolve 'command not found' errors with newer Docker versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d226f41-3f0a-420d-b80f-72fbbcbfa0b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d226f41-3f0a-420d-b80f-72fbbcbfa0b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

